### PR TITLE
Compile Android Studio project sample on Windows

### DIFF
--- a/sample/android/bind-java.bat
+++ b/sample/android/bind-java.bat
@@ -1,0 +1,5 @@
+@ECHO OFF
+cd /d %~dp0
+
+REM Generate Haxe inferface from Java file
+haxelib run bind java project.android/app/src/main/java/yourcompany/androidsample/AppAndroidInterface.java --namespace android --package android --export src --cwd %cd%

--- a/sample/android/build.bat
+++ b/sample/android/build.bat
@@ -1,0 +1,11 @@
+@ECHO OFF
+cd /d %~dp0
+
+REM Bind Java code to Haxe
+bind-java.bat
+
+REM Build Haxe code
+haxe build.hxml
+
+REM Compile Android binaries
+compile-android.bat

--- a/sample/android/compile-android.bat
+++ b/sample/android/compile-android.bat
@@ -1,0 +1,21 @@
+@ECHO OFF
+cd /d %~dp0
+cd bin
+
+REM Build an Android debug binary on required architectures (may take a while the first time)
+haxelib run hxcpp Build.xml -DHXCPP_CPP11 -DHXCPP_CLANG -Dandroid -DHXCPP_ARMV7 -Ddebug
+haxelib run hxcpp Build.xml -DHXCPP_CPP11 -DHXCPP_CLANG -Dandroid -DHXCPP_ARM64 -Ddebug
+haxelib run hxcpp Build.xml -DHXCPP_CPP11 -DHXCPP_CLANG -Dandroid -DHXCPP_ARMV5 -Ddebug
+haxelib run hxcpp Build.xml -DHXCPP_CPP11 -DHXCPP_CLANG -Dandroid -DHXCPP_X86 -Ddebug
+
+cd ..
+
+SET jni_dir=project.android\app\src\main\jniLibs
+IF NOT EXIST %jni_dir%\armeabi ( mkdir  %jni_dir%\armeabi)
+copy /Y/B bin\libMain-debug.so %jni_dir%\armeabi\libMain.so
+IF NOT EXIST %jni_dir%\armeabi-v7a ( mkdir  %jni_dir%\armeabi-v7a)
+copy /Y/B bin\libMain-debug-v7.so %jni_dir%\armeabi-v7a\libMain.so
+IF NOT EXIST %jni_dir%\arm64-v8a ( mkdir  %jni_dir%\arm64-v8a)
+copy /Y/B bin\libMain-debug-64.so %jni_dir%\arm64-v8a\libMain.so
+IF NOT EXIST %jni_dir%\x86 ( mkdir  %jni_dir%\x86)
+copy /Y/B bin\libMain-debug-x86.so %jni_dir%\x86\libMain.so


### PR DESCRIPTION
This pull request will add bat commands to compile sample project on Windows.
Also build.bat will stop because the Main.hx is not created from bind and respectively ```haxe build.hxml``` can't compile. 
 At the moment after compilation with hxcpp ( using compile-android.bat ) the file libMain-debug.so is not created ( maybe because ARMV5 is not supported anymore ?)